### PR TITLE
Fix darwin builds by adding iconv

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -53,7 +53,9 @@
 
             packages.default = craneLib.buildPackage {
               src = self;
-              nativeBuildInputs = [ pkgs.nixdoc ];
+              nativeBuildInputs =
+                [ pkgs.nixdoc ]
+                ++ lib.optionals pkgs.stdenv.isDarwin [ pkgs.iconv ];
             };
           };
       };


### PR DESCRIPTION
...without builds fails, the fact that the CI is green on Linux suggests that it's not needed there.